### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Bruno-366/Unbroken/security/code-scanning/1](https://github.com/Bruno-366/Unbroken/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only checks out code, installs dependencies, runs lint/type-check/build, and uploads artifacts, it does not require write access to repository contents. The minimal required permission is `contents: read`, which allows the workflow to read repository contents (needed for `actions/checkout`). You should add the following block at the top level of the workflow (before `jobs:`) to apply to all jobs:

```yaml
permissions:
  contents: read
```

This change should be made in `.github/workflows/ci.yml`, above the `jobs:` key (after the `on:` block). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
